### PR TITLE
Update environment-variables.md

### DIFF
--- a/docs/04-features/environment-variables.md
+++ b/docs/04-features/environment-variables.md
@@ -23,9 +23,11 @@ FILE_NAME=Cargo.toml
 Once you have created your environment file you can now load it using the following command.
 
 ```bash
-# atac -d <directory>
-# <directory> - The directory that contains the environment file
-atac -d .
+# if you use the default app directory or the ATAC_MAIN_DIR environment variable (OS side)
+atac
+
+# or with -d <directory> - The directory that contains the .env.my_env_name file
+atac -d <directory>
 ```
 
 ### Using Environment Variables

--- a/docs/04-features/environment-variables.md
+++ b/docs/04-features/environment-variables.md
@@ -20,6 +20,14 @@ ID=15
 FILE_NAME=Cargo.toml
 ```
 
+Once you have created your environment file you can now load it using the following command.
+
+```bash
+# atac -d <directory>
+# <directory> - The directory that contains the environment file
+atac -d .
+```
+
 ### Using Environment Variables
 
 To use these environment variables within your requests, reference them by writing `{{my_variable_name}}`. For example:


### PR DESCRIPTION
Added a bash example of how to open ATAC with an environment file.

I was following along the tutorial in the documentation and I assumed that just running ATAC without the -d option would load the environment file.

After digging through the help command I was able to figure out the correct way to load it.

I though maybe a small bash example would be useful in the documentation.